### PR TITLE
Update reinstalllocal.sh with Read/Write remount for /

### DIFF
--- a/etc/dbus-serialbattery/reinstalllocal.sh
+++ b/etc/dbus-serialbattery/reinstalllocal.sh
@@ -3,6 +3,10 @@
 DRIVER=/opt/victronenergy/dbus-serialbattery
 RUN=/opt/victronenergy/service-templates/dbus-serialbattery
 OLD=/opt/victronenergy/service/dbus-serialbattery
+
+#/dev/mmcblk1p3 mountpoint / was made read only in 2.91 release
+mount -o remount,rw /dev/mmcblk1p3 /
+
 if [ -d "$DRIVER" ]; then
   if [ -L "$DRIVER" ]; then
     # Remove old SymLink.


### PR DESCRIPTION
Partition **/dev/mmcblk1p3** with mountpoint **/** was made read only in 2.91 release of VenusOS

This allows the install scripts to run.